### PR TITLE
Fix console spam in Friends

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -125,7 +125,8 @@ module.exports = class ShowHiddenChannels extends Plugin {
       };
 
       this.patch('shc-unread', UnreadStore, 'hasUnread', (args, res) => {
-         return res && !getChannel(args[0]).isHidden();
+         var channel = getChannel(args[0]);
+         return res && channel !== undefined && !channel.isHidden();
       });
 
       this.patch('shc-mention-count', UnreadStore, 'getMentionCount', (args, res) => {


### PR DESCRIPTION
While in friends screen, console will spam get spammed with errors.
Seems like `args[0]` returns invalid ID and getChannel will return `undefined`. 
This PR fixes that.