### PR TITLE
Show last message date

### DIFF
--- a/components/LockedScreen.jsx
+++ b/components/LockedScreen.jsx
@@ -4,6 +4,23 @@ const { Text } = require('powercord/components');
 const { chat } = getModule(['chat', 'chatContent'], false);
 
 module.exports = React.memo((props) => {
+
+   function getDateFromSnowflake(number) {
+      try {
+         const id = parseInt(number);
+         const binary = id.toString(2).padStart(64, '0');
+
+         const excerpt = binary.substring(0, 42);
+         const decimal = parseInt(excerpt, 2);
+         const unix = decimal + 1420070400000;
+
+         return new Date(unix).toLocaleString();
+      } catch (e) {
+         console.error(e);
+         return 'Failed to get date';
+      }
+   }
+
    return <div className={['shc-locked-chat-content', chat].filter(Boolean).join(' ')}>
       <div className="shc-locked-notice" >
          <img
@@ -17,6 +34,11 @@ module.exports = React.memo((props) => {
          >
             This is a hidden channel.
          </Text>
+         {props.channel.lastMessageId &&
+            <Text>
+               Last message sent: {getDateFromSnowflake(props.channel.lastMessageId)}
+            </Text>
+         }
          <Text
             className="shc-no-access-text"
             color={Text.Colors.HEADER_SECONDARY}

--- a/components/LockedScreen.jsx
+++ b/components/LockedScreen.jsx
@@ -22,15 +22,14 @@ module.exports = React.memo((props) => {
             color={Text.Colors.HEADER_SECONDARY}
             size={Text.Sizes.SIZE_16}
          >
-            You cannot see the contents of this channel. {props.channel.topic ? 'However, you may see its topic.' : ''} 
+            You cannot see the contents of this channel. {props.channel.topic && 'However, you may see its topic.'}
          </Text>
-         {props.channel.topic ? (<>
+         {props.channel.topic &&
             <ChannelTopic
                key={props.channel.id}
                channel={props.channel}
                guild={props.guild}
-            />
-         </>) : ''}
+         />}
       </div>
    </div>;
 });

--- a/components/LockedScreen.jsx
+++ b/components/LockedScreen.jsx
@@ -4,57 +4,53 @@ const { Text } = require('powercord/components');
 const { chat } = getModule(['chat', 'chatContent'], false);
 
 module.exports = React.memo((props) => {
-
-   function getDateFromSnowflake(number) {
-      try {
-         const id = parseInt(number);
-         const binary = id.toString(2).padStart(64, '0');
-
-         const excerpt = binary.substring(0, 42);
-         const decimal = parseInt(excerpt, 2);
-         const unix = decimal + 1420070400000;
-
-         return new Date(unix).toLocaleString();
-      } catch (e) {
-         console.error(e);
-         return 'Failed to get date';
-      }
-   }
-
    return <div className={['shc-locked-chat-content', chat].filter(Boolean).join(' ')}>
-      <div className="shc-locked-notice" >
+      <div className='shc-locked-notice' >
          <img
-            className="shc-notice-lock"
-            src="/assets/755d4654e19c105c3cd108610b78d01c.svg"
+            className='shc-notice-lock'
+            src='/assets/755d4654e19c105c3cd108610b78d01c.svg'
          />
          <Text
-            className="shc-locked-channel-text"
+            className='shc-locked-channel-text'
             color={Text.Colors.HEADER_PRIMARY}
             size={Text.Sizes.SIZE_32}
          >
             This is a hidden channel.
          </Text>
-         {props.channel.lastMessageId &&
-            <Text
-                color={Text.Colors.INTERACTIVE_NORMAL}
-                size={Text.Sizes.SIZE_14}
-            >
-               Last message sent: {getDateFromSnowflake(props.channel.lastMessageId)}
-            </Text>
-         }
          <Text
-            className="shc-no-access-text"
+            className='shc-no-access-text'
             color={Text.Colors.HEADER_SECONDARY}
             size={Text.Sizes.SIZE_16}
          >
             You cannot see the contents of this channel. {props.channel.topic && 'However, you may see its topic.'}
          </Text>
-         {props.channel.topic &&
-            <ChannelTopic
-               key={props.channel.id}
-               channel={props.channel}
-               guild={props.guild}
+         {props.channel.topic && <ChannelTopic
+            key={props.channel.id}
+            channel={props.channel}
+            guild={props.guild}
          />}
+         {props.channel.lastMessageId && <Text
+            color={Text.Colors.INTERACTIVE_NORMAL}
+            size={Text.Sizes.SIZE_14}
+         >
+            Last message sent: {getDateFromSnowflake(props.channel.lastMessageId)}
+         </Text>}
       </div>
    </div>;
 });
+
+function getDateFromSnowflake(number) {
+   try {
+      const id = parseInt(number);
+      const binary = id.toString(2).padStart(64, '0');
+
+      const excerpt = binary.substring(0, 42);
+      const decimal = parseInt(excerpt, 2);
+      const unix = decimal + 1420070400000;
+
+      return new Date(unix).toLocaleString();
+   } catch (e) {
+      console.error(e);
+      return '(Failed to get date)';
+   }
+}

--- a/components/LockedScreen.jsx
+++ b/components/LockedScreen.jsx
@@ -35,7 +35,10 @@ module.exports = React.memo((props) => {
             This is a hidden channel.
          </Text>
          {props.channel.lastMessageId &&
-            <Text>
+            <Text
+                color={Text.Colors.INTERACTIVE_NORMAL}
+                size={Text.Sizes.SIZE_14}
+            >
                Last message sent: {getDateFromSnowflake(props.channel.lastMessageId)}
             </Text>
          }

--- a/index.jsx
+++ b/index.jsx
@@ -69,7 +69,7 @@ module.exports = class ShowHiddenChannels extends Plugin {
       };
 
       this.patch('shc-unread', UnreadStore, 'hasUnread', (args, res) => {
-         return res && !getChannel(args[0]).isHidden();
+         return res && !getChannel(args[0])?.isHidden();
       });
 
       this.patch('shc-permissions-can', Permissions, 'can', (args, res) => {


### PR DESCRIPTION
# Motivation
Inspired by https://github.com/X1nto/AliucordPlugins/tree/master/plugins/ShowHiddenChannels
Snowflake to date method from https://github.com/Pitabread8/Discord-Snowflakes/blob/main/snowflake.js#L28

# Visual

![image](https://user-images.githubusercontent.com/24937357/165519690-0b49a81a-25c5-4aef-b003-338a8658a2c4.png)
<sup>(Using `en-US` locale)</sup>

# Info

I think this is fine for the performance branch, as it the computation isn't that heavy. It would need to be merged into the features branch as well, though.

Feedback is appreciated :wink: 